### PR TITLE
No more gfortran-7 on Ubuntu 20.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [gfortran-7, gfortran-8, gfortran-9]
+        compiler: [gfortran-8, gfortran-9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [gfortran-8, gfortran-9]
+        compiler: [gfortran-8, gfortran-9, gfortran-10]
 
     steps:
     - uses: actions/checkout@v2

--- a/test/test_map.f90
+++ b/test/test_map.f90
@@ -78,7 +78,7 @@ complex(real128), dimension(:), allocatable :: c16
 character(len=100) :: s_compiler_version
 logical :: compiler_has_O3
 complex(real32), dimension(:), allocatable :: c4res
-logical, dimension(:), allocatable :: c4rescheck
+logical :: c4rescheck
 
 n = 1
 ntests = 10
@@ -120,23 +120,21 @@ c16 = [cmplx(1._real128, 0._real128), &
        cmplx(2._real128, 0._real128), &
        cmplx(3._real128, 0._real128)]
 
+! Special case for gfortran-10 with -O3 if detected
+c4rescheck = all(map(xpowx_c4, c4) == c4**c4)  ! the default
 s_compiler_version = compiler_version()  ! e.g., `GCC version {major}.{minor}.{patch}`
-if ( s_compiler_version(1:3) == 'GCC' ) then
-  compiler_has_O3 = index(compiler_options(), '-O3') /= 0
-  
-  ! Special case for gfortran-10 with -O3
-  if ( s_compiler_version(13:14) == '10' .and. compiler_has_O3 ) then
-    print *, 'using special check for gfortran-10 -O3 for complex real32'
-    ! c4rescheck = map(xpowx_c4, c4) == c4**c4  ! T T F even though `map(xpowx_c4, c4) == c4**c4` is T T T
-    c4res = map(xpowx_c4, c4)
-    c4rescheck = c4res == c4**c4  ! splitting it into two lines we are able to get T T T
-    tests(n) = assert(all(c4rescheck), 'map,  complex real32')
-  else
-    tests(n) = assert(all(map(xpowx_c4, c4) == c4**c4), 'map,  complex real32')
-  end if
-else
-  tests(n) = assert(all(map(xpowx_c4, c4) == c4**c4), 'map,  complex real32')
+compiler_has_O3 = index(compiler_options(), '-O3') /= 0
+if ( &
+  s_compiler_version(1:3) == 'GCC' &
+  .and. s_compiler_version(13:14) == '10' &
+  .and. compiler_has_O3 &
+) then
+  print *, 'using special check for gfortran-10 -O3 for complex real32'
+  ! Note: `x = map(xpowx_c4, c4) == c4**c4` is T T F (via `print *, x`) even though `map(xpowx_c4, c4) == c4**c4` is T T T
+  c4res = map(xpowx_c4, c4)
+  c4rescheck = all(c4res == c4**c4)  ! by assigning `c4res` first we are able to get T T T in the comparison
 end if
+tests(n) = assert(c4rescheck, 'map,  complex real32')
 n = n + 1
 
 tests(n) = assert(all(map(xpowx_c8, c8) == c8**c8), 'map,  complex real64')

--- a/test/test_map.f90
+++ b/test/test_map.f90
@@ -60,7 +60,7 @@ end function xpowx_c16
 end module mod_map_functions
 
 program test_map
-use iso_fortran_env, only:int8, int16, int32, int64, real32, real64, real128
+use iso_fortran_env, only:int8, int16, int32, int64, real32, real64, real128, compiler_version, compiler_options
 use testing, only:assert, initialize_tests, report_tests
 use functional
 use mod_map_functions
@@ -74,6 +74,11 @@ integer :: n, ntests
 complex(real32), dimension(:), allocatable :: c4
 complex(real64), dimension(:), allocatable :: c8
 complex(real128), dimension(:), allocatable :: c16
+
+character(len=100) :: s_compiler_version
+logical :: compiler_has_O3
+complex(real32), dimension(:), allocatable :: c4res
+logical, dimension(:), allocatable :: c4rescheck
 
 n = 1
 ntests = 10
@@ -115,7 +120,23 @@ c16 = [cmplx(1._real128, 0._real128), &
        cmplx(2._real128, 0._real128), &
        cmplx(3._real128, 0._real128)]
 
-tests(n) = assert(all(map(xpowx_c4, c4) == c4**c4), 'map,  complex real32')
+s_compiler_version = compiler_version()  ! e.g., `GCC version {major}.{minor}.{patch}`
+if ( s_compiler_version(1:3) == 'GCC' ) then
+  compiler_has_O3 = index(compiler_options(), '-O3') /= 0
+  
+  ! Special case for gfortran-10 with -O3
+  if ( s_compiler_version(13:14) == '10' .and. compiler_has_O3 ) then
+    print *, 'using special check for gfortran-10 -O3 for complex real32'
+    ! c4rescheck = map(xpowx_c4, c4) == c4**c4  ! T T F even though `map(xpowx_c4, c4) == c4**c4` is T T T
+    c4res = map(xpowx_c4, c4)
+    c4rescheck = c4res == c4**c4  ! splitting it into two lines we are able to get T T T
+    tests(n) = assert(all(c4rescheck), 'map,  complex real32')
+  else
+    tests(n) = assert(all(map(xpowx_c4, c4) == c4**c4), 'map,  complex real32')
+  end if
+else
+  tests(n) = assert(all(map(xpowx_c4, c4) == c4**c4), 'map,  complex real32')
+end if
 n = n + 1
 
 tests(n) = assert(all(map(xpowx_c8, c8) == c8**c8), 'map,  complex real64')


### PR DESCRIPTION
It seems like such runners are now being used for this kind of run when `ubuntu-latest` is specified. And we [can see](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) that they do not include a `gfortran-7`, so the job fails ([example](https://github.com/zmoon/functional-fortran/runs/2118154011)).