### PR TITLE
Remove gfortran-8 from the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [gfortran-8, gfortran-9, gfortran-10]
+        compiler: [gfortran-9, gfortran-10]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I think this is needed because `ubuntu:latest` is now 20.04 which doesn't provide gfortran-8. At least it seems so from the CI logs. I hope this makes CI happy again.