### PR TITLE
Allowed subscripting the last index of array.

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,6 +1,6 @@
 name = "functional"
-version = "0.6.1"
+version = "0.6.2"
 license = "BSD-3-Clause"
 author = "Milan Curcic"
 maintainer = "milancurcic@hey.com"
-copyright = "Copyright (c) 2016-2020, functional-fortran contributors"
+copyright = "Copyright (c) 2016-2022, functional-fortran contributors"

--- a/src/functional.f90
+++ b/src/functional.f90
@@ -3629,7 +3629,7 @@ pure function subscript_i1(x, ind) result(subscript)
   integer(i1), dimension(:), allocatable :: subscript
   integer(i1), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3646,7 +3646,7 @@ pure function subscript_i2(x, ind) result(subscript)
   integer(i2), dimension(:), allocatable :: subscript
   integer(i2), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3663,7 +3663,7 @@ pure function subscript_i4(x, ind) result(subscript)
   integer(i4), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3680,7 +3680,7 @@ pure function subscript_i8(x, ind) result(subscript)
   integer(i8), dimension(:), allocatable :: subscript
   integer(i8), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3697,7 +3697,7 @@ pure function subscript_r4(x, ind) result(subscript)
   real(r4), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3714,7 +3714,7 @@ pure function subscript_r8(x, ind) result(subscript)
   real(r8), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3731,7 +3731,7 @@ pure function subscript_r16(x, ind) result(subscript)
   real(r16), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3748,7 +3748,7 @@ pure function subscript_c4(x, ind) result(subscript)
   complex(r4), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3765,7 +3765,7 @@ pure function subscript_c8(x, ind) result(subscript)
   complex(r8), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))
@@ -3782,7 +3782,7 @@ pure function subscript_c16(x, ind) result(subscript)
   complex(r16), dimension(:), allocatable :: subscript
   integer(i4), dimension(:), allocatable :: indices
   integer :: i
-  indices = pack(ind, ind > 0 .and. ind < size(x))
+  indices = pack(ind, ind > 0 .and. ind <= size(x))
   allocate(subscript(size(indices)))
   do concurrent(i = 1:size(indices))
     subscript(i) = x(indices(i))

--- a/test/test_subscript.f90
+++ b/test/test_subscript.f90
@@ -10,7 +10,7 @@ logical :: test_failed
 integer :: n, ntests
 
 n = 1
-ntests = 11
+ntests = 12
 call initialize_tests(tests, ntests)
 
 tests(n) = assert(all(subscript([1_int8, 2_int8, 3_int8], [2_int8]) == [2_int8]), &
@@ -43,6 +43,10 @@ n = n + 1
 
 tests(n) = assert(size(subscript([1, 2, 3], [0])) == 0, &
                   'subscript out of bounds returns empty array')
+n = n + 1
+
+tests(n) = assert(all(subscript([1, 2, 3], [3]) == [3]), &
+                  'subscript of last element')
 n = n + 1
 
 tests(n) = assert(all(subscript(arange(cmplx(1._real32, 0._real32), &


### PR DESCRIPTION
Bugfix for issue 26. Now the `subscript` function will be able to give access to the last element of an array.